### PR TITLE
Add manual test cases (password recovery + logout) and update README

### DIFF
--- a/manual-tests/README.md
+++ b/manual-tests/README.md
@@ -1,0 +1,20 @@
+# Manual Tests
+
+Esta pasta contém **casos de teste manuais** criados como parte do portfólio de QA.  
+
+## Estrutura dos Casos de Teste
+Cada caso segue o formato:
+
+- **ID / Nome do caso de teste**  
+- **Objetivo**: O que o teste valida.  
+- **Pré-condições**: Estado inicial necessário.  
+- **Passos**: Sequência de ações para execução.  
+- **Resultado Esperado**: O que deve acontecer se o sistema estiver correto.  
+
+## Casos incluídos
+- CT-001 – Login válido  
+- CT-002 – Recuperação de senha  
+- CT-003 – Logout  
+- CT-004 – Campos vazios  
+
+> Estes casos ilustram situações comuns em sistemas web e fazem parte do estudo para ISTQB.

--- a/manual-tests/logout_test_case.md
+++ b/manual-tests/logout_test_case.md
@@ -1,0 +1,16 @@
+# CT-003 – Logout
+
+**Objetivo:**  
+Validar se o sistema encerra corretamente a sessão do usuário.  
+
+**Pré-condições:**  
+- Usuário autenticado no sistema.  
+
+**Passos:**  
+1. Clicar em “Logout” ou “Sair” no menu principal.  
+2. Confirmar ação, se solicitado.  
+
+**Resultado Esperado:**  
+- Sessão é encerrada.  
+- Usuário é redirecionado para a tela de login.  
+- Tentativa de acessar páginas restritas sem login mostra mensagem de acesso negado.

--- a/manual-tests/password_recovery_test_case.md
+++ b/manual-tests/password_recovery_test_case.md
@@ -1,0 +1,19 @@
+# CT-002 – Recuperação de Senha
+
+**Objetivo:**  
+Validar se o usuário consegue redefinir a senha com e-mail válido.  
+
+**Pré-condições:**  
+- Usuário já cadastrado com e-mail válido.  
+- Navegador ou app aberto na tela de login.  
+
+**Passos:**  
+1. Clicar em “Esqueci minha senha”.  
+2. Inserir o e-mail válido cadastrado.  
+3. Confirmar solicitação.  
+4. Acessar e-mail para verificar recebimento do link de redefinição.  
+5. Redefinir senha com sucesso.  
+
+**Resultado Esperado:**  
+- Sistema envia link de redefinição para o e-mail informado.  
+- Usuário consegue cadastrar nova senha e acessar o sistema.


### PR DESCRIPTION
### Changes introduced
- Added manual test case for password recovery (CT-002)
- Added manual test case for logout (CT-003)
- Created README.md inside /manual-tests folder to document the test case structure and conventions

### Why this change?
These additions expand the manual test coverage for common authentication flows and improve repository documentation for easier navigation.
